### PR TITLE
Add var for Twitter, update more SEO changes to FOSS@MAGIC

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,9 @@ description: > # this means to ignore newlines until "baseurl:"
   at the RIT MAGIC Center. Learn about open source activities and
   courses at the Rochester Institute of Technology.
 github-repo: 'https://github.com/FOSSRIT/fossrit.github.io'
-
 url: 'https://fossrit.github.io'
+twitter_account: "@RITMAGIC"
+
 # Build settings
 markdown: kramdown
 permalink: pretty # no .html extension needed/wanted

--- a/_includes/layout/seo-meta.html
+++ b/_includes/layout/seo-meta.html
@@ -3,7 +3,7 @@
     <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
     <meta property="og:site_name" content="{{ site.title }}" />
     <meta name="application-name" content="{{ site.title }}" />
-    <meta name="twitter:site" content="@RITlug" />
+    <meta name="twitter:site" content="{{ site.twitter_account }}" />
     <meta name="twitter:card" content="summary_large_image" />
     {% if page.excerpt %}
         <meta name="description" content="{{ page.excerpt | strip_html | truncate: 155 }}" />
@@ -45,19 +45,19 @@
         <meta property="og:image" content="{{ site.url }}{{ page.images.first }}" />
         <meta name="twitter:image" content="{{ site.url }}{{ page.images.first }}" />
     {% else %}
-        <meta property="og:image" content="{{ site.url }}/img/ritlug-large.png" />
-        <meta name="twitter:image" content="{{ site.url }}/img/ritlug-large.png" />
+        <meta property="og:image" content="{{ site.url }}/img/logo.png" />
+        <meta name="twitter:image" content="{{ site.url }}/img/logo.png" />
     {% endif %}
     <script type="application/ld+json">
     {
         "@context": "http://schema.org",
         "@type": "Organization",
-        "name": "RIT Linux Users Group",
-        "alternateName": "RITlug",
-        "logo": "{{ site.url }}/img/ritlug-large.png",
+        "name": "{{ site.title }}",
+        "alternateName": "{{ site.title-abbrev }}",
+        "logo": "{{ site.url }}/img/logo.png",
         "url": "{{ site.url }}",
         "sameAs": [
-            "https://twitter.com/RITlug"
+            "https://twitter.com/{{ site.twitter_account }}"
         ],
         "knowsAbout": [
             "Linux",


### PR DESCRIPTION
There was more remains from RITlug than I realized. I made a first attempt at bringing some of the SEO-specific content up-to-date to help our brand visibility and not get our site confused with RITlug.