### PR TITLE
Set SEO keywords with variable in site config (closes #26)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,14 @@ description: >  # this symbol ignores newlines
 
 email: sj@magic.rit.edu
 github-repo: "https://github.com/FOSSRIT/fossrit.github.io"
+seo_keywords: >  # this symbol ignores newlines
+  "FOSS@MAGIC",
+  "FOSSRIT",
+  "RIT FOSS",
+  "RIT MAGIC Center",
+  "Rochester Institute of Technology",
+  "open source",
+  "Stephen Jacobs"
 twitter_account: "@RITMAGIC"
 url: "https://fossrit.github.io"
 

--- a/_includes/layout/seo-meta.html
+++ b/_includes/layout/seo-meta.html
@@ -60,8 +60,7 @@
             "https://twitter.com/{{ site.twitter_account }}"
         ],
         "knowsAbout": [
-            "Linux",
-            "Open source"
+            {{ site.seo_keywords }}
         ],
         "location": {
             "@type": "Place",


### PR DESCRIPTION
This pull request does two things:

1. Sets the SEO keywords in `seo-meta.html` with variable in `_config.yml`
2. Adds some suggested keywords to help optimize the site's visibility in search engines

I'm tagging @ct-martin and @desnudopenguino for a review if either of them have time. Eventually, once I complete #19, the need for reviewing smaller changes like this will go away.