### PR TITLE
Add development environment instructions (closes #19)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+How to contribute
+=================
+
+Want to develop or contribute to this project?
+Contributions and improvements are appreciated and welcome.
+This guide explains how to set up a development environment and make a contribution.
+
+
+## Create a development environment
+
+This project uses a [**Docker**](https://en.wikipedia.org/wiki/Docker_%28software%29) container to create a development environment.
+This solution works with Docker on Linux, macOS, and Windows.
+We use Docker to run a container to build and serve the website.
+Then, when you make changes, they are reflected immediately in your running copy of the site when you press "Save".
+
+### Pre-requisites
+
+Install Docker:
+
+* Linux
+  * [Fedora](https://developer.fedoraproject.org/tools/docker/docker-installation.html)
+  * [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+* [macOS](https://docs.docker.com/docker-for-mac/install/)
+* [Windows](https://docs.docker.com/docker-for-windows/install/)
+
+### Run development script
+
+In a new window, run the [`start_devel_env.sh`](https://github.com/FOSSRIT/fossrit.github.io/blob/master/start_devel_env.sh) script.
+This script downloads a Jekyll Docker container and builds the website.
+Once it starts, you can access a local version of the website by visiting this URL:
+
+```
+http://localhost:4000
+```
+
+## Submitting contributions
+
+More detailed steps will be documented in the future.
+For now, if you want to contribute, submit a new pull request.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ This website covers both institution programs and work as well as the FOSS acade
 It is also used to communicate other information of interest to the RIT FOSS community.
 
 
-## Legal notes
+## Contributing
+
+For help with contributing and making a development environment, see [CONTRIBUTING.md](https://github.com/FOSSRIT/fossrit.github.io/blob/master/.github/CONTRIBUTING.md).
+
+
+## Legal
 
 This website is licensed under the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/).
 It is based off of [RITlug/ritlug.github.io](https://github.com/RITlug/ritlug.github.io), a [Creative Commons Zero v1.0 Universal](https://github.com/RITlug/ritlug.github.io/blob/fe94d190d92ae3d13bbc743f81eab2d004ba5f16/LICENSE) project.

--- a/start_devel_env.sh
+++ b/start_devel_env.sh
@@ -1,10 +1,16 @@
-#!/usr/bin/bash
+#!/bin/bash
 #
 # Create development environment using a Docker container
 #
 
 JEKYLL_VERSION=3.8
 
+# Ensure _site directory is created for Jekyll engine
+if [ ! -d ./_site ]; then
+    mkdir ./_site
+fi
+
+# Serve the site via Docker and update site when files changed in repo
 docker run --rm \
     -p 4000:4000 \
     -v "$PWD:/srv/jekyll:Z" \


### PR DESCRIPTION
This pull request adds new documentation to explain how to create a development environment to build and preview the fossrit.github.io website locally.

I tagged a few people for review because I'd like feedback to improve these instructions. By following the below instructions, you should be able to run a local development instance of the fossrit.github.io website. It should only take executing a script. If you have Docker already installed, it should "Just Work™".

Could anyone actually try this and let me know if it works easily for them? Is anything confusing or could it be better explained?