### PR TITLE
Minor content revisions to Get Involved page

### DIFF
--- a/events/_posts/2018-11-06-election-night-hackathon.md
+++ b/events/_posts/2018-11-06-election-night-hackathon.md
@@ -3,12 +3,12 @@ layout: event
 title: Election Night Hackathon 2018
 authors:
 - Justin W. Flory
-excerpt: Students and faculty collaborate and work on projects during the 2018 US midterm elections.
+excerpt: Students and faculty collaborated and worked on projects during the 2018 US midterm elections.
 images:
 - /events/assets/2018/11/election-night-hackathon-01.jpg
 - /events/assets/2018/11/election-night-hackathon-02.jpg
 ---
-Students and faculty collaborate and work on projects during the 2018 US midterm elections.
+Students and faculty collaborated and worked on projects during the 2018 US midterm elections.
 
 {% include content-blocks/gallery.html %}
 

--- a/get-involved.md
+++ b/get-involved.md
@@ -28,11 +28,14 @@ Looking for more information? Email Prof. Stephen Jacobs at {{ site.email }}.
 ##### Open source projects
 
 * [GitHub organization](https://github.com/FOSSRIT)
+* [foss-profiles](https://github.com/FOSSRIT/foss-profiles): Students, faculty, and alums affiliated with RIT FOSS community
+* [infrastructure](https://github.com/FOSSRIT/infrastructure): Open source configuration management for FOSS@MAGIC server infrastructure
 
 
 ##### Events
 
 * Weekly FOSS Hours on {{ site.meeting-day }}s, {{ site.meeting-time }}
 * FOSS Talks: monthly guest speakers on topics related to FOSS
-* Hackathons (e.g. Election Night Hackathon)
-* [ImagineRIT](https://rit.edu/imagine)
+* Hackathons (e.g. [Election Night Hackathon](/events/2018/11/06/election-night-hackathon))
+* [Rochester Maker Faire](https://rochester.makerfaire.com/)
+* [Imagine RIT](https://rit.edu/imagine)


### PR DESCRIPTION
Expands some of the lists towards the bottom of the _Get involved_ page. Also includes some revisions suggested by @itprofjacobs.

![Screenshot of updated _Get Involved_ page](https://user-images.githubusercontent.com/4721034/50853261-bf0aa200-134f-11e9-95cc-3370d5ccc765.png "Screenshot of updated Get Involved page")
