### PR TITLE
Correct "Humanitarian and Civics" typo

### DIFF
--- a/announcements/_posts/2019-05-21-cfp-announcement.md
+++ b/announcements/_posts/2019-05-21-cfp-announcement.md
@@ -5,8 +5,8 @@ layout: post
 date: 2019-05-21
 ---
 
-FOSS@MAGIC is proud to announce the debut of the first-ever The Future is Open mini-conference.
-The Future is Open is a one-day event to engage the wider RIT community with open source opportunities, projects, and research happening on campus.
+FOSS@MAGIC is proud to announce the debut of the first-ever **The Future is Open** mini-conference.
+**The Future is Open** is a one-day event to engage the wider RIT community with open source opportunities, projects, and research happening on campus.
 We invite alumni, friends of the program, and those interested in learning about a variety of open source projects and programs created on RIT's campus to join current students, faculty, and staff for the event.
 
 A call for proposals (CfP) is now [open](https://www.google.com/url?q=https://forms.gle/563vz3qZAgMXRJNk9&sa=D&ust=1558124859124000). 
@@ -22,7 +22,7 @@ All backgrounds are encouraged and welcomed. We hope for the content of our talk
 ## Suggested Topics
 
 We are seeking presentations in the following topics:
--   Humantairian and Civics
+-   Humanitarian and Civics
 -   Games
 -   DevOps
 -   Open Science


### PR DESCRIPTION
Embolden conference title in running text

Fixes #50