### PR TITLE
FIO: "Alumni Panel" -> "Alum Panel" for inclusivity

### DIFF
--- a/events/_posts/2019-10-26-the-future-is-open.md
+++ b/events/_posts/2019-10-26-the-future-is-open.md
@@ -143,7 +143,7 @@ Humanitarian organizations are using open data and cloud services to help disast
         <div class="card mb-4">
             <div class="card-header" style="background-color:#F76902;color:white;font-size:larger;">
                 <span class="badge" style="background-color:white;color:#F76902;">10am-11:30am</span>
-                Alumni Panel
+                Alum Panel
             </div>
             <div class="card-body">
                 <h4 class="card-title">How FOSS courses kick-started our careers</h4>


### PR DESCRIPTION
This commit makes a tiny change of wording the "Alumni Panel" to the
"Alum Panel". Because:

1) There is an alumna on the panel.
2) "Alums" is a gender-neutral version of the word.

Sooooo, making the shift here.