### PR TITLE
Add "White House Champions of Change" event, from @decause

### DIFF
--- a/events/_posts/2013-07-23-white-house-champions-change.md
+++ b/events/_posts/2013-07-23-white-house-champions-change.md
@@ -1,0 +1,33 @@
+---
+layout: event
+title: White House Champions of Change
+authors:
+- Remy DeCausemaker
+excerpt: Student-led project entitled “Sky Time” selected for inclusion in the White House Champions of Change event on July 23rd, 2013 in Washington, D.C.
+---
+
+The [RIT Center for Media, Arts, Games, Interaction & Creativity](https://www.rit.edu/magic/) (MAGIC) is pleased to announce that a student-led project entitled “[Sky Time](https://github.com/FOSSRIT/SkyTime)” has been selected for inclusion in the White House Champions of Change event on July 23rd in Washington, D.C.
+SkyTime is an educational game for the [Sugar Desktop Environment](https://sugarlabs.org/) running on the XO laptop of the [One Laptop Per Child (OLPC)](https://web.archive.org/web/20191221235809/http://one.laptop.org/about/mission) initiative.
+The event celebrates the best projects to emerge from the nationwide Hack for Change event that was part of the National Day of Civic Hacking.
+In particular, the Champions of Change program will highlight “…extraordinary leaders in transformative civic hacking and civic engagement” and we are thrilled that RIT students have been chosen to be included in this event.
+More information on the Champions of Change program is available on the [White House website](https://web.archive.org/web/20130728184044/http://www.whitehouse.gov/champions).
+
+The student team members responsible for "Sky Time" are:
+
+* Jennifer Kotler, Major in Biomedical Illustration, CIAS¹
+* Ryan Stush, New Media Interactive Development, GCCIS
+* David Wilson, Game Design and Development, GCCIS
+* Ian Furry, Game Design and Development, GCCIS
+
+(¹_Jennifer is the team lead and will be representing the team in Washington, D.C._)
+
+“Sky Time” began as a class project in a course on Humanitarian Free and Open Source Software offered through the RIT School of Interactive Games and Media, designed by [Professor Stephen Jacobs](https://www.rit.edu/directory/sxjics-stephen-jacobs) and taught by Justin Sherrill.
+From there, it was refined during the Rochester Hack for Change Hackathon, an event hosted by the RIT MAGIC Center and orchestrated by Remy DeCausemaker, Research Associate at the RIT Lab for Technological Literacy's FOSS@RIT initiative.
+The hackathon was one of 95 events participating in the White House's National Day of Civic Hacking June 1st-2nd.
+
+Currently, all four students are working through FOSS@RIT initiative this summer.
+Ryan, David and Ian are working with a fourth student on another OLPC Game, a version of the venerable "Lemonade Stand", through the Summer Undergraduate Research Fellows program.
+Jennifer is hired by FOSS@RIT as a full-time artist/designer working on several projects, including Lemonade Stand.
+
+This concept of taking class projects, ideas, and teamwork, and extending the work, adding polish, and focus through the MAGIC Center towards greater public adoption and impact is exactly what we had hoped for when the MAGIC Center was created by President Destler in February.
+We are immensely proud of our students and their work, as well as the faculty and staff that supported the efforts that enabled this activity, and look forward to their participation at the event in Washington this summer.


### PR DESCRIPTION
This was an accidental find, but it was too good to not include on our
new website. I stumbled across the only running archive I know of for
the old FOSSbox website:

http://www.samlucidi.com/fossbox/articles/decause/magic-centers-fossrit-program-sends-students-to-white-house-champions-of-change-event.html

In a best effort to preserve that data, I've moved it over into our new
site and decided to publish it under the _Events_ page.

I only wish I had pictures to include here.

cc: @decause @jenneh @ramstush @DAWacker @itprofjacobs @mansam

![Screenshot of rendered event page](https://user-images.githubusercontent.com/4721034/75378785-4f80aa80-58a2-11ea-98e1-02bf17d745ef.png "Screenshot of rendered event page")