### PR TITLE
events: Add FOSS + Syracuse hackathon from @decause

### DIFF
--- a/events/_posts/2011-07-12-syracuse-student-sandbox-hackathon.md
+++ b/events/_posts/2011-07-12-syracuse-student-sandbox-hackathon.md
@@ -1,0 +1,32 @@
+---
+layout: event
+title: FOSS@RIT & SU Student Sandbox Hackathon
+authors: Remy DeCausemaker
+excerpt: FOSS@RIT co-hosts a hackathon with our Neighbors to the East from the SU Student Sandbox - a student business and start-up incubator run out of Syracuse University
+---
+
+_Read the event recap of this event on Opensource.com_: [**Bridging the Boxes: Hacker Matchmaking in Upstate New York, The Open Source Way**](https://opensource.com/education/11/8/bridging-boxes-hacker-matchmaking-upstate-new-york-opensource-way)
+
+
+## When
+
+July 12th, 3pm - 3am
+
+
+## What
+
+FOSS@RIT will be co-hosting a hackathon with our Neighbors to the East from the [SU Student Sandbox](https://web.archive.org/web/20110128211601/http://www.syracusestudentsandbox.com/) - a student business and start-up incubator run out of [Syracuse University](https://www.syracuse.edu/).
+
+
+## Who
+
+Designers, coders, and other business minded folk are encouraged to attend.
+
+Please RSVP to Remy DeCausemaker.
+
+
+## Where
+
+Center for Student Innovation (Bldg 87-1600)
+
+[View Larger Map](https://www.openstreetmap.org/?mlat=43.08323&mlon=-77.67992#map=17/43.08333/-77.67919)


### PR DESCRIPTION
This was an event we did in collaboration with Syracuse University in
2011:

http://www.samlucidi.com/fossbox/event-decause-fossrit--su-student-sandbox-hackathon.html

![Screenshot of rendered page from local environment](https://user-images.githubusercontent.com/4721034/75387590-90cc8680-58b1-11ea-99a7-de2c5e624e29.png "Screenshot of rendered page from local environment")