### PR TITLE
events: Add 2011 @jlew breakfast send-off from @decause

### DIFF
--- a/events/_posts/2011-05-19-breakfast-send-off.md
+++ b/events/_posts/2011-05-19-breakfast-send-off.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title: FOSS@RIT Breakfast Send-off
+authors: Remy DeCausemaker
+excerpt: Justin Lewis, the cornerstone of the FOSSBox for the last 2 years is leaving RIT. We're having a little breakfast in his honor.
+---
+
+Justin Lewis, the cornerstone of the FOSSBox for the last 2 years is leaving RIT.
+We're having a little breakfast in his honor.
+
+**When**: 05/19/2011 - 9:30am


### PR DESCRIPTION
I stumbled on this one and thought it was a little piece of FOSSbox
history worth archiving. It was a breakfast send-off for @jlew when he
moved on from RIT organized by @decause.

http://www.samlucidi.com/fossbox/event-decause-fossrit-breakfast-sendoff.html

![Screenshot from local dev environment](https://user-images.githubusercontent.com/4721034/75388653-5d8af700-58b3-11ea-91a0-0509eba8c640.png "Screenshot from local dev environment")