### PR TITLE
events: Add 2011 Linux installfest by @cprofitt from @decause

### DIFF
--- a/events/_posts/2011-04-23-linux-installfest.md
+++ b/events/_posts/2011-04-23-linux-installfest.md
@@ -1,0 +1,12 @@
+---
+layout: event
+title: Linux Installfest 2011
+authors: Remy DeCausemaker
+excerpt: Local FOSS Rockstar CProfitt leads a day of linux installs and appreciation in the Center for Student Innovation
+---
+
+Local FOSS Rockstar [CProfitt](https://web.archive.org/web/20140822115544/https://wiki.ubuntu.com/cprofitt) will be leading a day of linux installs and appreciation in the [Center for Student Innovation](https://www.openstreetmap.org/?mlat=43.08323&mlon=-77.67992#map=17/43.08333/-77.67919).
+
+Stay Tuned, more details to come.
+
+Email Remy DeCausemaker for more info and/or to RSVP.


### PR DESCRIPTION
Another historical grab, this time featuring Rochester's own @cprofitt
leading a 2011 Linux installfest at RIT. Also came from @mansam's
FOSSbox archive, written by @decause.

http://www.samlucidi.com/fossbox/event-decause-linux-installfest.html

I wonder if pictures exist anywhere for this one.

![Screenshot of local preview](https://user-images.githubusercontent.com/4721034/75389314-531d2d00-58b4-11ea-9d75-e03c06e7076f.png "Screenshot of local preview")