### PR TITLE
projects: Update TigerOS year and project repositories

### DIFF
--- a/projects/_posts/2019-12-31-tigeros.html
+++ b/projects/_posts/2019-12-31-tigeros.html
@@ -3,9 +3,11 @@ layout: default
 title: TigerOS
 permalink: /tigeros
 authors:
-- Christian Martin (@ctmartin)
-- Tim Zabel (@tjzabel)
-- Aidan Kahrs (@axk4545)
+- Aidan Kahrs
+- Christian Martin
+- Josh Bicking
+- Regina Locicero
+- Tim Zabel
 images:
 - /projects/assets/tigeros/tigeros_orange_background.png
 - /projects/assets/tigeros/tigeros_postinstall.png
@@ -22,7 +24,7 @@ excerpt: <p>TigerOS is a Fedora Remix that beautifully utilizes Linux to meet th
             <h2>What is TigerOS?</h2>
             <p>TigerOS is a Fedora Remix that beautifully utilizes Linux to meet the demands of RIT students and faculty.</p>
             <p>Join the conversation! Find us in <a href="https://webchat.freenode.net/?channels=rit-tigeros"><code>#rit-tigeros</code></a> on IRC for development discussions and support.</p>
-            <a href="https://github.com/RITlug/TigerOS" class="btn btn-lg btn-primary">Find on GitHub</a>
+            <a href="https://gitlab.com/RITlug/TigerOS" class="btn btn-lg btn-primary">Find on GitLab</a>
         </div>
         <div class="col-12 col-md-3" style="margin-bottom:1.2em;">
             <h2>Download</h2>


### PR DESCRIPTION
This commit updates TigerOS for the FOSS@MAGIC Projects part of the
website. I added @gen1e and @jibby0 as contributors, updated the GitHub
button to point to the new GitLab, and updated the year from 2018 to
2019. As far as I know, the last major activity on TigerOS was last
semester.

cc: @tjzabel

![Screenshot from local preview](https://user-images.githubusercontent.com/4721034/76028334-622d5c00-5f00-11ea-85c3-9b92d97ea51f.png "Screenshot from local preview")