### PR TITLE
Add Travis CI gated deployments (closes #44)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+---
+os: linux
+language: ruby
+rvm:
+  - 2.6.5
+
+script:
+  - bundle exec jekyll build
+  - bundle exec htmlproofer --empty-alt-ignore --http-status-ignore=999 --url-ignore "/projects/" ./_site
+
+deploy:
+  cleanup: false
+  keep_history: true
+  provider: pages
+  target_branch: master
+  token: "$GITHUB_TOKEN"
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+    - secure: cEWgFXZ7aNgM8iCgNz6j1laT/8tZh257UX4IYDlOXlxzKkjlqFnT7H6lSch53TEwF8HuUMS6lMCFBgPic5R96dHEmxqZocmSWYyPcuzpZRgDHrVJ8v6e8Ja4bdAUeEit0dN5veQI1H45ydfs/6m25O7W/EROUyDG7/dAZ71mxXLO9u2Nj8rmvfD0MNe/s8E7h5yfa7wuDS5ToW4O0PwwgUo24w35QYmFcc7qWtmVWKGsZoesWGu/TRbGYrZhC5B+ZoXP3N2sswJUPmJDCOZLcdoxmLnRRmnnVJAu7r6v1Ejds1UaXBdCzl/mrMy4Uk7Dhjw6i+sHU3N0szcfqT1KEyaOLiYC6/9KT4U5VUl1Jw7dfzy6Ew7eVsSQLBMMd5gElr+ivyIalSRar4JLDtdIACnqsmebHF0K2B1hlES7wcB4MC91us7AZBfzBxL7lsK8UWJCze4apDLaAP+F/Rdj6MbJ4hHeCChRFFWfxidCC6VFS+13ALAFbaY2lVGcnIGKv04mcSGfoISlTJQ4aEhH488/wcmYX/s1Kwzgg+POrfba2c9030a2jnUMChe0oBeGhiR8BBg5e8Z9+rhfG9ZyO9xlP1EDL1+CkYSabn8DewLAl3jPzAHV2lXihEBMaVqqqUCzTR1K19AfuoO8Ab0yaQ88exauZOhU7Mf8H5WW+Fo=
+
+addons:
+  apt_packages: libcurl4-openssl-dev
+
+# caching bundler gem packages will speed up build
+cache: bundler

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ==============================================
 
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
+[![Build Status](https://travis-ci.org/FOSSRIT/fossrit.github.io.svg?branch=master)](https://travis-ci.org/FOSSRIT/fossrit.github.io)
 
 Official website for Free and Open Source Software @ RIT MAGIC Center and FOSS academia
 

--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ page_events:
 # --- build settings ---
 
 excerpt_separator: <!--more-->
+exclude: [vendor] # https://jekyllrb.com/docs/continuous-integration/travis-ci/
 future: true  # allow events in the future (for calendar feed)
 markdown: kramdown
 permalink: pretty  # no .html extensions


### PR DESCRIPTION
This commits adds Travis CI support for FOSSRIT/fossrit.github.io. It
builds the site with Jekyll, checks for HTML errors and broken links
with `html-proofer`, and if successful and run on `master`, it deploys
the latest build of the site from Travis.

I used the official Jekyll docs to set up testing, although there were
several things missing that took me a long time to figure out how to get
that part working:

https://jekyllrb.com/docs/continuous-integration/travis-ci/

Never forget, `bundler exec`. :grimacing:

It is worth noting a few things are disabled in `html-proofer` that
realistically should be enabled. We _should_ check for alt tags, we
should _not_ have to ignore `/projects/` but we do because they are
appended with `.html` extensions for some reason, unlike the rest of the
site. The `permalink` metadata we set in project profiles is likely to
blame for this.

At time of commit/pull request, CI is failing. Another PR coming later
will fix the 404 errors and other broken links that it discovered while
putting this PR together.

Additionally, I used the official Travis CI docs for setting up
automatic deployments from Travis:

https://docs.travis-ci.com/user/deployment/pages/

Additionally, I validated the Travis config in the beta Travis CI Config
explorer/validator tool:

https://config.travis-ci.com/

Closes #44.

---

:memo: README: Add Travis CI testing badge

Show the latest status of `master` branch builds in Travis CI on the
README.