### PR TITLE
Fix various HTML errors/broken links to make CI pass

### DIFF
--- a/announcements/_posts/2019-04-16-imagine-rit.md
+++ b/announcements/_posts/2019-04-16-imagine-rit.md
@@ -24,7 +24,7 @@ FOSS Letters are four 1 ft. tall letters that spell the word "FOSS" originally c
 They are illuminated by RGB LED strips.
 The letter colors are controlled by an [open source web interface](https://github.com/FOSSRIT/FOSSLetters) in front of the display.
 The web interface is hosted on a Raspberry Pi and publicly accessible to anyone on the Internet.
-FOSS Letters were created out of the [IGME 585 Project in Free and Open Source Software Development](https://www.rit.edu/gccis/igm/sites/rit.edu.gccis.igm/files/images/FOSS-MN%20Semesters.pdf) class at RIT.
+FOSS Letters were created out of the [IGME 585 Project in Free and Open Source Software Development](https://www.rit.edu/study/curriculum/e4af015b-d2bf-4a7e-9a48-08c7d25dc4d1) class at RIT.
 
 ### Arduino heartbeat sensor
 

--- a/announcements/index.html
+++ b/announcements/index.html
@@ -20,5 +20,5 @@ title: Announcements
         </div>
     </article>
     {% endfor %}
-    <a class="btn btn-primary btn-block" href="/announcements/archive" style="margin-bottom:1.2em;">View Older</a>
+    <a class="btn btn-primary btn-block" href="/announcements" style="margin-bottom:1.2em;">View Older</a>
 </div>

--- a/projects/_posts/2019-12-31-tigeros.html
+++ b/projects/_posts/2019-12-31-tigeros.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: TigerOS
-permalink: /tigeros
+permalink: /projects/tigeros
 authors:
 - Aidan Kahrs
 - Christian Martin


### PR DESCRIPTION
CI is introduced in #114. While putting that PR together, it found several valid things on our site that are actually broken or unexpected. This PR fixes them, so when #114 is merged, it should pass and also deploy our site to production.

---

d51cd9ccc5f852aae51789b089880887634f2cda — :bookmark_tabs: **announcements: Fix 404 for FOSS Minor curriculum**

Previously in an Imagine RIT announcement, I linked to the PDF of the
FOSS courses to talk about work that came from the IGME-585 course. RIT
did the ol' switcheroo on us, so this points that link to the new place
for FOSS minor curriculum.

---

4856857c9b8ef6afbe046182ce06146e6b87dceb —  :link: **announcements: Fix broken URL**

For some reason, this link was broken. Might have been old cruft from
the RITlug website circa 2015.

---

c29335f22c3112efcef1ba5d01d57824353fb495 — :tiger: **projects: Make TigerOS conform to link format of all projects**

TigerOS is special on the RITlug website, but here we want it to conform
to the same permalink style that all other projects adhere to. No double
standards pls!

---