### PR TITLE
ci: Use Travis dpl v2 to deploy on GitHub Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ script:
   - bundle exec htmlproofer --empty-alt-ignore --http-status-ignore=999 --url-ignore "/projects/" ./_site
 
 deploy:
-  cleanup: false
-  keep_history: true
-  provider: pages
-  target_branch: master
+  provider: pages:git
   token: "$GITHUB_TOKEN"
+  edge: true
 
 env:
   global:


### PR DESCRIPTION
This commit is a follow-up to discussion in `#rit-foss-admin` about how
the site is deployed from the latest `master` branch. tl;dr: This
switches us to the beta release of Travis's deployment API:

https://docs.travis-ci.com/user/deployment-v2/providers/pages/

I'm breaking this commit message into two parts: expected outcome and
why I think this works.

Expected outcome
================

Only applicable to builds on `master`. Travis builds Jekyll static
content in CI job. If build is successful, clone repo and check out
`master` branch. Keep dependencies installed in `.bundle/` and `vendor/`
untracked. Push static content to GitHub Pages.

I referenced a dpl v1 job to see how this works before:

https://travis-ci.org/FOSSRIT/fossrit.github.io/builds/659540947

Why I think this works
======================

The git directory is not cleaned up after previous steps, so everything
generated in the `jekyll build` step should still be present in the
build. This is why `cleanup: false` was set in the `.travis.yml` before,
but this is the default behavior in dpl v2:

https://docs.travis-ci.com/user/deployment-v2#cleaning-up-the-git-working-directory

Given that `name` and `email` for git commits use the current git commit
author name and email, I am making a bet that the site is deployed
without adding commits to the target branch. I believe `jekyll build` is
run and no new files are committed to the repo. If this were true, it
would mean `.bundle/` and `vendor/` would be committed to `master`, as I
understand it. Which is not the case. `_site/` is ignored in the
`.gitignore`.

Unfortunately there is no way to test this PR until it is merged to
`master`, since the deployment phase only works on the default branch.
But it will be interesting to see what happens.

cc: @ct-martin