### PR TITLE
ci: Build and deploy to gh-pages branch (closes #119)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ script:
   - bundle exec htmlproofer --empty-alt-ignore --http-status-ignore=999 --url-ignore "/projects/" ./_site
 
 deploy:
-  cleanup: false
+  committer_from_gh: true
   keep_history: true
+  local_dir: "_site/"
   provider: pages
-  target_branch: master
+  skip_cleanup: true
   token: "$GITHUB_TOKEN"
+  on:
+    branch: master
 
 env:
   global:


### PR DESCRIPTION
This adjusts the Travis config to build the site and push the static
site content in `_site/` to the `gh-pages` branch. Once this is enabled,
I'll enable the `gh-pages` branch in the repo settings and set up branch
protections.

Closes #119.