### PR TITLE
librecorps: Add suggested SJ edits

### DIFF
--- a/librecorps.md
+++ b/librecorps.md
@@ -24,7 +24,30 @@ Up until now, LibreCorps runs single instance by single instance.
 Our three-year plan builds it into an on-going, student-driven, faculty-managed, standing FOSS consultancy program.
 
 
+## Our work with UNICEF Innovation Fund
+
+RIT LibreCorps has partnered with the UNICEF Office of Innovation since 2014.
+In recent years, LibreCorps collaborated with the [Innovation Fund](https://unicefinnovationfund.org/), a pooled funding vehicle to quickly assess, fund and grow open-source solutions that have been developed in new and emerging markets.
+RIT LibreCorps provides students experienced in open source development and community-building as mentors for different teams in UNICEF's Innovation Fund.
+Portfolio teams work together with RIT student employees to create and build sustainable communities around their open source projects.
+You can read more about this work on our Opensource.com article, [_LibreCorps mentors humanitarian startups on how to run the open source way_](https://opensource.com/article/19/12/humanitarian-startups-open-source).
+
+
 ## Resources
 
 Need help or advice on building an open source project and community?
 Check out the [**LibreCorps Resources**](https://librecorps.github.io/resources/) site, a self-serve knowledgebase of information on open source best practices.
+You can also find templates used for open source mentorship below:
+
+* [Milestone roadmap template](https://docs.google.com/document/d/1dCu1wP3TDOHsmnWMhyu4XzolIz61kfGeMMAvgMd2rbQ/edit?usp=sharing)
+* [Self-evaluation rubric](https://docs.google.com/spreadsheets/d/1gfI6Jp2_scHGL9uC8r07fi96AZIcf6l_5b9lgkE6SDM/edit?usp=sharing)
+
+
+## Past LibreCorps student contributors
+
+You can find out more about our past and current LibreCorps students on their LinkedIn profiles:
+
+* [Brendan Whitfield](https://www.linkedin.com/in/brendan-whitfield-3b87aa89/)
+* [Mike Nolan](https://www.linkedin.com/in/mikenolansoftware/)
+* [Justin W. Flory](https://www.linkedin.com/in/justinwflory/)
+* [Kent Reese](https://www.linkedin.com/in/kent-reese-31225a10b/)


### PR DESCRIPTION
Added a few suggested edits by @itprofjacobs:

1. Our work with UNICEF Innovation Fund: Specifically describing the
   mentorship and collaboration with portfolio teams
2. Resources: Add roadmap template and self-evaluation rubric
3. Past LibreCorps student contributors: Brief shout-out for our past
   and current students who worked on RIT LibreCorps initiatives