### PR TITLE
config: Generate a sitemap and highlight it in robots.txt

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,11 +38,22 @@ page_events:
 
 # --- build settings ---
 
+# https://jekyllrb.com/docs/continuous-integration/travis-ci/
+exclude:
+  - build.sh
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE.txt
+  - Rakefile
+  - README.md
+  - vendor
 excerpt_separator: <!--more-->
-exclude: [vendor] # https://jekyllrb.com/docs/continuous-integration/travis-ci/
 future: true  # allow events in the future (for calendar feed)
 markdown: kramdown
 permalink: pretty  # no .html extensions
+plugins:
+  - jekyll-feed
+  - jekyll-sitemap
 
 
 # --- meeting schedule settings ---

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://fossrit.github.io/sitemap.xml


### PR DESCRIPTION
This is a Search Engine Optimization (S.E.O.) tweak. A sitemap is a file
for search engines that creates a digital map of all the content
published on a website. Using a plugin, Jekyll will create one for
fossrit.github.io and put it at the root of the domain. Using a
`robots.txt` is a more explicit way we tell other search engines that a
sitemap is present and to go and use it for indexing.