### PR TITLE
seo-meta: Add meta tag for Google Search Console verification

### DIFF
--- a/_includes/layout/seo-meta.html
+++ b/_includes/layout/seo-meta.html
@@ -1,3 +1,4 @@
+    <meta name="google-site-verification" content="S1TGL46nruysWj0a2nw64L1D6MYxZj_QB4Ku4yrhkJU" />
     <meta property="og:title" content="{{ page.title }}" />
     <meta name="twitter:title" content="{{ page.title }}" />
     <meta property="og:url" content="{{ site.url }}{{ page.url }}" />


### PR DESCRIPTION
This commit adds a new `<meta>` tag that appears in the `<head>` of
every page. It verifies that admin access to `fossrit.github.io` is
correctly given in the Google Search Console interface.

My intention is to use this tool to submit the sitemap to Google and
also promote specific pages on our site in Google.