### PR TITLE
Add new "Open@RIT" page to track ongoing work (closes #146)

### DIFF
--- a/_data/tabs.yml
+++ b/_data/tabs.yml
@@ -1,16 +1,19 @@
+---
 - name: Home
   link: /
 
 - name: About
   dropdown:
-  - name: About
-    link: /about/
-  - name: LibreCorps
-    link: /librecorps/
-  - name: Events
-    link: /events/
-  - name: Projects
-    link: /projects/
+    - name: About
+      link: /about/
+    - name: LibreCorps
+      link: /librecorps/
+    - name: Open@RIT
+      link: /open-rit/
+    - name: Events
+      link: /events/
+    - name: Projects
+      link: /projects/
 
 - name: Announcements
   link: /announcements/

--- a/open-rit.md
+++ b/open-rit.md
@@ -1,0 +1,38 @@
+---
+layout: page
+title: Open@RIT
+slug: open-rit
+
+---
+
+## What is Open@RIT?
+
+Open@RIT is an effort initiated by [Professor Stephen Jacobs](https://www.rit.edu/directory/sxjics-stephen-jacobs), and supported by the Office of the Vice President of Research, to build support for an Open Source Programs Office at RIT.
+
+To date, fifty faculty and staff across thirty-seven different units of RIT have asked to be added to the mailing list for the group.
+Fifteen of those have been attending on-line meetings and/or contributing to the “[_Wish List for Activities_][1]”.
+
+
+## How to get involved
+
+1. Join the Mailing List.
+   Send a request to be added to `sj` [at] `magic` [dot] `rit` [dot] `edu`.
+2. Read, and if you’d like to, comment on and/or contribute to the “[_Activities_][1]” document.
+3. Fill out [the form][2] we are using to populate a prototype directory of people and projects in the Open across campus.
+   The intent of this action is to allow for greater collaboration across units and to begin to collect metrics on the University’s impact in and on all things Open.
+4. Contribute to the “[_Knowledgebase_][3]” we’re crowd-sourcing for Open@RIT.
+
+### How to contribute to [Knowledgebase][3]
+
+You can do this in one of two ways:
+
+1. **If you know how to use git/GitHub**:
+   [Open a pull request][4].
+1. **If you don’t know how to use them**:
+   Add links to the “[_Activities_][1]” document.
+   Someone will make comparisons between the two (for now) and move things over.
+
+[1]: https://docs.google.com/document/d/1n4mR22Rx3YHbKYSj9SMGTpkYo6aTwMqUbZWPz5o4ijs/edit
+[2]: https://docs.google.com/forms/d/e/1FAIpQLSdgvRRvziPbdo6-2gADJDOexGbND-YI4QYnOkpQCoQ_eW981w/viewform
+[3]: https://fossrit.github.io/knowledgebase/
+[4]: https://github.com/FOSSRIT/knowledgebase


### PR DESCRIPTION
This commit adds a new page to the FOSSRIT website,
https://fossrit.github.io/open-rit/, that describes the on-going work to
explore an Open Source Programs Office at RIT. This is based on copytext
sent to me from @itprofjacobs with minor tweaks of my own.

Needs to be merged by 2020-04-23 @ 1:50pm US/Eastern.

Closes #146.

![Screenshot of local preview](https://user-images.githubusercontent.com/4721034/80129809-9e2a8800-8565-11ea-9eb8-6594a76c753b.png "Screenshot of local preview")