### PR TITLE
Add FOSSRIT People/Profiles link to site navbar

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ task :test do
     :check_html => true,
     :empty_alt_ignore => true,
     :http_status_ignore => [0,999],
-    :url_ignore => [/projects/],
+    :url_ignore => [/people/, /projects/],
     :cache => {
       :timeframe => '6w'
     },

--- a/_data/tabs.yml
+++ b/_data/tabs.yml
@@ -21,5 +21,8 @@
 - name: Calendar
   link: /calendar/
 
+- name: People
+  link: /people/
+
 - name: Get Involved
   link: /get-involved/


### PR DESCRIPTION
This adds an outlink to the FOSSRIT People page. This better integrates
the work done by @kennedy for the FOSSRIT Profiles page into our web
presence. It does not close FOSSRIT/people#72 though. We need to link
back to this website from the People page in order to close that issue.