### PR TITLE
calendar: Add Virtual FOSS Hours for Summer 2020 (closes #150)

### DIFF
--- a/meetings-meetups/_posts/2020-05-07-summer-foss-hours.md
+++ b/meetings-meetups/_posts/2020-05-07-summer-foss-hours.md
@@ -1,12 +1,11 @@
 ---
 layout: redirect
 redirect: https://meet.jit.si/rit-foss-hours
-date-start: "2020-03-26 17:00"
-date-end: "2020-03-26 18:00"
+date-start: "2020-05-07 17:00"
+date-end: "2020-05-07 18:00"
 location: "https://meet.jit.si/rit-foss-hours"
-title: "FOSS Hours"
-rrule: "FREQ=WEEKLY;UNTIL=20200423T190000"
-sitemap: false
+title: "Virtual FOSS Hours"
+rrule: "FREQ=WEEKLY;INTERVAL=2;UNTIL=20200820T190000"
 
 ---
 


### PR DESCRIPTION
This commit adds a new calendar event for Summer 2020 (specifically 7
May to 13 August). Once every other week, the FOSS Family will gather
together to say hi until we see each other again (hopefully) in Fall
semester.

Closes #150.

![Screenshot from local preview](https://user-images.githubusercontent.com/4721034/80266861-28f5aa80-866c-11ea-993c-60a2e24bc636.png)
