### PR TITLE
calendar: Do not include calendar pages in sitemap

### DIFF
--- a/meetings-meetups/_posts/2020-01-16-foss-hours.md
+++ b/meetings-meetups/_posts/2020-01-16-foss-hours.md
@@ -6,5 +6,7 @@ date-end: "2020-01-16 19:00"
 location: "MSS-3190"
 title: "FOSS Hours"
 rrule: "FREQ=WEEKLY;UNTIL=20200305T190000"
+sitemap: false
+
 ---
 Come meet other students and faculty involved with FOSS efforts at RIT!

--- a/meetings-meetups/_posts/2020-03-26-virtual-foss-hours.md
+++ b/meetings-meetups/_posts/2020-03-26-virtual-foss-hours.md
@@ -6,6 +6,8 @@ date-end: "2020-03-26 18:00"
 location: "https://meet.jit.si/rit-foss-hours"
 title: "FOSS Hours"
 rrule: "FREQ=WEEKLY;UNTIL=20200423T190000"
+sitemap: false
+
 ---
 Come meet other students and faculty involved with FOSS efforts at RIT!
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Disallow: /meetings-meetups/
 Allow: /
 
 Sitemap: https://fossrit.github.io/sitemap.xml


### PR DESCRIPTION
Google Search Console threw an error when it tried to crawl this URL:

https://fossrit.github.io/meetings-meetups/2020/03/26/virtual-foss-hours/

Why it is a problem doesn't make much sense to me, since I wasn't
blocking it in our `robots.txt`, but Google seems to think it is
blocked. However, when users see this content, they are actually looking
at fossrit.github.io/calendar/ and not the above URL, so we actually
don't need Google or any search engine crawling those pages.

So, this adds Front Matter that explicitly excludes calendar events in
the sitemap and also adds a `Disallow` rule to tell search engines not
to crawl that directory.

This should fix the error reported in the Google Search Console.

![Screenshot of error in Google Search Console: Blocked by robots.txt](https://user-images.githubusercontent.com/4721034/80297294-d8f01400-874f-11ea-955e-b8fe1cb25955.png "Screenshot of error in Google Search Console: Blocked by robots.txt")