### PR TITLE
Announcement for Open Works in Academia summit

### DIFF
--- a/announcements/_posts/2022-07-21-open-works-in-academia-summit
+++ b/announcements/_posts/2022-07-21-open-works-in-academia-summit
@@ -1,0 +1,33 @@
+---
+author: Karsten Wade
+title: "Open Work in Academia Summit — Sep 7-9, 2022 in Rochester, NY"
+layout: post
+
+---
+
+Join us for the [first summit regarding Open Work in Academia](https://www.rit.edu/openworksummit/) September 7-9, 2022 in Rochester, NY.
+
+During this summit, attendees will have the opportunity to meet, listen to, and collaborate with some of the leaders in the fields of [Open Work](https://fossrit.github.io/open-work-definition/
+) in Industry, Colleges and Universities and related sectors.
+
+
+## Date and location
+
+September 7-9, 2022
+
+Hyatt Regency Rochester
+125 East Main Street
+Rochester, NY, 14604, US
+
+## Attendee registration
+
+Registration is now open.
+The goal of this event is to foster conversations across different areas of specialization and, as a result, we are limiting the registration to 100 attendees.
+There’s been significant initial interest in this event since our first announcement and we expect to sell out quickly.
+This is planned as an in-person event, COVID-willing, but we’ll move to virtual if we must.
+
+[Register here](https://apps.ideal-logic.com/ritreg?key=5HCZ-DDY7S_K9KH-5PTF_d45a6151b0e2)
+
+For more information about the event, such as the event's Code of Conduct and details about sponsorship, refer to the main event webpage:
+
+[https://www.rit.edu/openworksummit/](https://www.rit.edu/openworksummit/)

--- a/events/_posts/2010-11-04-election-night-hackathon.md
+++ b/events/_posts/2010-11-04-election-night-hackathon.md
@@ -32,7 +32,7 @@ Most media outlets task fleets of interns with following results pages just like
 This process is painful and often by the time you go through all of this manual copy-pasting and refreshing, the results are already out of date.
 `.XML` files, however, work very similarly to something like an RSS feed, and provide an ongoing stream of data to the flash site.
 So why not try to tap into that stream to back-end and automatically update the `.html` results, instead of doing everything by hand?
-This is exactly what WXXI was looking to implement, and exactly what FOSS@RIT's Ace Hacker, [Nate Case](http://nathanielca.se/category/fossrit.html) was able to execute.
+This is exactly what WXXI was looking to implement, and exactly what FOSS@RIT's Ace Hacker, [Nate Case](https://web.archive.org/web/20180903235749/nathanielca.se/category/fossrit.html) was able to execute.
 After about 30 minutes of phone calls to the MCBOE, and `whois`'ing various IP addresses, we managed to locate the (at the time, inactive) results page for Monroe County, and another active results page put out by the same software/voting machine provider in London, Ontario, Canada.
 From the results on that page, we were able to prototype an `.XML`->`.html` results page that would likely work with Monroe County's results once they were live!
 


### PR DESCRIPTION
Adding an announcement about the summit to the webpage.

The event is findable by searching for the exact terms, and the Open Works
definition has almost zero search engine juice. I'm hoping some meaningful
cross-linking will began to help with that, and things to tweet about too.