### PR TITLE
Add Webrick to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'rake'
   gem 'rspec'
   gem 'selenium-webdriver'
-  gem "webrick", "~> 1.7"
   gem 'webdrivers'
+  gem "webrick", "~> 1.7"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,5 @@ group :test do
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end
+
+gem "webrick", "~> 1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'rake'
   gem 'rspec'
   gem 'selenium-webdriver'
+  gem "webrick", "~> 1.7"
   gem 'webdrivers'
 end
 
-gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,6 +329,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webrick (1.7.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
@@ -347,6 +348,7 @@ DEPENDENCIES
   rspec
   selenium-webdriver
   webdrivers
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.22
+   2.3.22


### PR DESCRIPTION
Found this when trying to build the website locally.

When running the build.sh file, I ran into an error message:
```
cannot load such file -- webrick (LoadError)
```

Apparently on the latest version of Jekyll, we need to add this package, or serving will no longer work (but building the site works just fine).  See: https://jekyllrb.com/news/2022/03/27/jekyll-3-9-2-released/

This pull simply adds the webrick package so the build.sh file is able to serve again with the latest version of jekyll.