### PR TITLE
Updated annoucement feed to use the site's description, and not RITlug's

### DIFF
--- a/feeds/latest.xml
+++ b/feeds/latest.xml
@@ -5,7 +5,7 @@ layout: null
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
-    <description>{{ "RIT Linux Users Group Announcements" | xml_escape }}</description>
+    <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>


### PR DESCRIPTION
I noticed the Announcements RSS feed used RITlug's description, and not FOSS@RIT's description.

With this update, the <description> tag will now use the one in the config.yml file.  It will look something like this:

```
<description>
Center of gravity for Free and Open Source Software at the Rochester Institute of Technology. Learn about open source activities and academia at RIT.
</description>
```